### PR TITLE
Make the API client resilient to server errors

### DIFF
--- a/lib/loqate/api_result.rb
+++ b/lib/loqate/api_result.rb
@@ -15,6 +15,19 @@ module Loqate
       @items = items
     end
 
+    def self.error(status:)
+      new(
+        [
+          {
+            'Error' => '-2',
+            'Description' => 'Something went wrong - please try again later',
+            'Resolution' => 'Try again later',
+            'Cause' => "Server returned response with #{status}"
+          }
+        ]
+      )
+    end
+
     # Whether the response contains errors
     #
     # @return [Boolean] true if the response has errors and false otherwise

--- a/lib/loqate/client.rb
+++ b/lib/loqate/client.rb
@@ -38,8 +38,12 @@ module Loqate
 
       response = HTTP.headers(headers).get(configuration.host + endpoint, params: formatted_params)
 
-      body = JSON.parse(response.body)
-      APIResult.new(body.fetch('Items'))
+      if response.status.success?
+        body = JSON.parse(response.body)
+        APIResult.new(body.fetch('Items'))
+      else
+        APIResult.error(status: response.status)
+      end
     end
 
     private

--- a/spec/loqate/client_spec.rb
+++ b/spec/loqate/client_spec.rb
@@ -34,6 +34,29 @@ RSpec.describe Loqate::Client do
       expect(response.items).to be_empty
     end
 
+    context 'when the response has failed' do
+      it 'returns an error' do
+        stub_request(:get, 'https://api.addressy.com/path?Key=fake').to_return(status: 500, body: 'Error')
+
+        response = client.get('/path')
+        expect(response.errors?).to be(true), 'Response should have errors'
+      end
+
+      it 'creates an error that looks like a Loqate error' do
+        stub_request(:get, 'https://api.addressy.com/path?Key=fake').to_return(status: 500, body: 'Error')
+
+        response = client.get('/path')
+        expect(response.items).to eq(
+          [
+            'Error' => '-2',
+            'Description' => 'Something went wrong - please try again later',
+            'Resolution' => 'Try again later',
+            'Cause' => 'Server returned response with 500 Internal Server Error'
+          ]
+        )
+      end
+    end
+
     context 'when the host is configured' do
       let(:configuration) { Loqate::Configuration.new(api_key: api_key, host: 'http://example.com') }
       let(:client) { described_class.new(configuration) }
@@ -47,3 +70,4 @@ RSpec.describe Loqate::Client do
     end
   end
 end
+# ~> -:1:in `<main>': uninitialized constant RSpec (NameError)


### PR DESCRIPTION
## What

Make the API client resilient to server errors

## Why

* When server returns a failure response, the gem throws a `JSON::ParserError`
* This is because the client never checks for a success or failure in the server response and assumes it's formatted as JSON
* When a 502 is sent back, here's the crash:

```
JSON::ParserError (767: unexpected token at '<html><head>)
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
```

## Fix

* Check `response.status.success?` before parsing the JSON
* If the response has failed, we return an API result containing an error that conforms to the Loqate error format
* When the server returns an error, this will return the error back to the client (or throw an exception if you're calling a bang method)